### PR TITLE
add links to 'see also' in python api ref

### DIFF
--- a/docs/os_diff/python_api.md
+++ b/docs/os_diff/python_api.md
@@ -38,7 +38,7 @@ Connects to the given database, and creates a TableSegment instance
 * **key_columns** – Names of the key columns
 * **thread_count** – Number of threads for this connection (only if using a threadpooled db implementation)
 
-See also: `connect()`
+See also: [`connect()`](#connect)
 
 ----
 
@@ -69,7 +69,7 @@ Note: The following parameters are used to override the corresponding attributes
 list(diff_tables(table1, table1))
 []`
 
-See also: TableSegment, HashDiffer, JoinDiffer
+See also: [TableSegment](#tablesegment), [HashDiffer](#hashdiffer), [JoinDiffer](#joindiffer)
 
 ----
 


### PR DESCRIPTION
Per [Erez's comment](https://github.com/datafold/data-diff/pull/263#issuecomment-1287311273), add links to "See also" in Python API Reference.

Other links can/should be added later, but this is a start and the place where they would have been most conspicuously/inconveniently missing.