### PR TITLE
Mute overview video

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -91,4 +91,4 @@ import TabItem from '@theme/TabItem';
 
 ## See Datafold in Action
 
-<ReactPlayer playing controls url='https://datafold-public.s3.us-west-2.amazonaws.com/homepage-demo.mp4'  loop="loop" muted="" width="100%" height="auto%"/>
+<ReactPlayer playing controls url='https://datafold-public.s3.us-west-2.amazonaws.com/homepage-demo.mp4'  loop="loop" muted="true" width="100%" height="auto%"/>


### PR DESCRIPTION
Keep autoplay on, but mute the video so that you don't hear it start every time you navigate to the overview page