### PR TITLE
spruce up features (lineage, catalog, diff, alerts)

### DIFF
--- a/docs/features/alerts.md
+++ b/docs/features/alerts.md
@@ -4,13 +4,13 @@ title: Alerts
 ---
 # Alerting
 
-With Datafold's alerts you'll be able to quickly monitor the data flowing through your pipelines.&#x20;
+With Datafold's alerts, you can quickly monitor the data flowing through your pipelines.
 
 ![](../../static/img/alerts_gif.gif)
 
-Turn any SQL query into an alert that emails or messages your team. Get faster incident response times with code-free alerting that are customizable to your data.
+Turn any SQL query into an alert that emails or messages your team. Get faster incident response times with code-free alerts that are customizable to your data.
 
-Datafold’s model learns how your data works to adapt to the seasonality and trends in your data to create dynamic thresholds with anomaly detection. Adjust the sensitivity or add custom anomaly detection to optimize your signal-to-noise ratio.
+Datafold learns how your data works to adapt to the seasonality and trends in your data to create dynamic thresholds with anomaly detection. Adjust the sensitivity or add custom anomaly detection to optimize your signal-to-noise ratio.
 
 Customize alert triggers and notifications so only the right people are informed. Subscribe to alerts through Slack, Email, PagerDuty, or custom webhooks.
 

--- a/docs/features/catalog-lineage.md
+++ b/docs/features/catalog-lineage.md
@@ -11,7 +11,7 @@ To include more details in your Catalog, you can sync metadata from dbt and your
 ## Column-level Lineage
 
 ![](../../static/img/lineage_detail.png)
-After connecting your data warehouse, Datafold analyzes every SQL statement that is used to create the tables and views. Then, Datafold produces a graph of dependencies to easily visualize dependencies. See how data is produced and consumed - even correlated subqueries, `CASE WHEN` statements, and other complex queries are covered.
+After connecting your data warehouse, Datafold parses the query logs to construct and visualize dependencies at both the table and column levels. See how data is produced, consumed, and transformed. Datafold supports complex queries, such as correlated subqueries, `CASE WHEN` statements, and window functions.
 
 No additional developer resources are needed to unlock this capability. Simply connect your data warehouse and explore your lineage graph. 
 
@@ -19,4 +19,5 @@ To view the column-level Lineage of any table in your warehouse:
 
 * Navigate to Catalog.
 * Click on any table in the Catalog.
-* Click on Lineage.
+* Click on the Lineage tab.
+* By default, table lineage will be shown. Click on the Columns dropdown of any table to view column-level lineage.

--- a/docs/features/catalog-lineage.md
+++ b/docs/features/catalog-lineage.md
@@ -4,13 +4,19 @@ title: Catalog + Column-level Lineage
 ---
 ## Catalog
 ![](../../static/img/catalog_landing.png)
-With the Datafold Catalog you can quickly see row counts, nulls and column distributions. We'll gather up this information and display it for every table and data source that you add. 
+With the Datafold Catalog, you can quickly see row counts, nulls, and column distributions for tables in your data warehouse.
 
-For more detail, you can sync metadata from dbt and your data warehouse to create a single source of truth. You can implement custom tags to easily categorize and filter the data sets. 
+To include more details in your Catalog, you can sync metadata from dbt and your data warehouse to create a single source of truth. You can implement custom tags to easily categorize and filter the data sets. 
 
 ## Column-level Lineage
-After connecting your data warehouse, Datafold analyzes every SQL statement and produces the graph of dependencies to easily visualize your data. See how data is produced and consumed - even correlated subqueries, CASE WHEN statements, and other complex queries are covered.
-
-No additional developer resources are needed, simply connect your data warehouse and you can explore your lineage graph. 
 
 ![](../../static/img/lineage_detail.png)
+After connecting your data warehouse, Datafold analyzes every SQL statement that is used to create the tables and views. Then, Datafold produces a graph of dependencies to easily visualize dependencies. See how data is produced and consumed - even correlated subqueries, `CASE WHEN` statements, and other complex queries are covered.
+
+No additional developer resources are needed to unlock this capability. Simply connect your data warehouse and explore your lineage graph. 
+
+To view the column-level Lineage of any table in your warehouse:
+
+* Navigate to Catalog.
+* Click on any table in the Catalog.
+* Click on Lineage.

--- a/docs/features/catalog-lineage.md
+++ b/docs/features/catalog-lineage.md
@@ -20,4 +20,5 @@ To view the column-level Lineage of any table in your warehouse:
 * Navigate to Catalog.
 * Click on any table in the Catalog.
 * Click on the Lineage tab.
-* By default, table lineage will be shown. Click on the Columns dropdown of any table to view column-level lineage.
+* By default, table-level lineage will be shown. 
+* Click on the Columns dropdown of any table to view column-level lineage.

--- a/docs/features/data_diff.md
+++ b/docs/features/data_diff.md
@@ -3,11 +3,11 @@ sidebar_position: 1
 title: Data Diff
 ---
 # Data Diff
-Data Diff enables teams to become proactive with their data testing and easily allows you to validate migrations before breaking changes have a chance to make it to production. 
+Data Diff enables teams to be proactive with their data testing. With Data Diff, you can easily validate migrations before breaking changes make it to production. 
 
-Data Diff automates regression testing with integration into the CI process through GitHub and GitLab. With Diff you can validate every source code change so that you can easily see how changes in your code impact the data produced across all rows and columns.
+Data Diff automates regression testing with integration into the CI process through GitHub and GitLab. With Data Diff, you can validate every source code change and easily see how changes in your code impact the data produced across all rows and columns.
 
-Data Diff checks every change to a data pipeline and highlights how the change in source code will affect the data produced by the pipeline. Save hours of time on manual testing while you avoid regressions in ETL.
+Data Diff checks every change to a data pipeline and highlights how the change in source code will affect the data produced by the pipeline. Save hours of time on manual testing while avoiding regressions in ETL.
 
 Diffs can run automatically on a new code change and flag potential issues directly in your pull request. Using Datafold, you can easily validate the data changes before merging in any potential issues. Let code reviewers, team leadership, and all stakeholders evaluate the impact of a change at a glance.
 

--- a/docs/features/data_diff.md
+++ b/docs/features/data_diff.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Data Diff
 ---
 # Data Diff
-Data Diff enables teams to be proactive with their data testing. With Data Diff, you can easily validate migrations before breaking changes make it to production. 
+Data Diff enables teams to be proactive with their data testing. With Data Diff, you can easily validate that updates to your data pipelines won't cause breaking changes in production. 
 
 Data Diff automates regression testing with integration into the CI process through GitHub and GitLab. With Data Diff, you can validate every source code change and easily see how changes in your code impact the data produced across all rows and columns.
 

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 
 <table >
  <tr>
-    <td>Get the row-level impact of changes you're making to your dbt models within your workflow – all without needing to write any SQL tests.</td>
+    <td>Get the row-level impact of changes made to dbt models within your workflow – all without needing to write any SQL tests.</td>
     <td><video src="https://datafold-public.s3.us-west-2.amazonaws.com/small-video-01.mp4" preload="metadata" autoplay="autoplay" loop="loop" muted="" width="100%" height="auto%"></video></td>
  </tr>
 </table>

--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -28,7 +28,7 @@ import TabItem from '@theme/TabItem';
 
 <table >
  <tr>
-    <td>Get the row-level impact of changes you’re making to your dbt models within your workflow – all without needing to write any SQL tests.</td>
+    <td>Get the row-level impact of changes you're making to your dbt models within your workflow – all without needing to write any SQL tests.</td>
     <td><video src="https://datafold-public.s3.us-west-2.amazonaws.com/small-video-01.mp4" preload="metadata" autoplay="autoplay" loop="loop" muted="" width="100%" height="auto%"></video></td>
  </tr>
 </table>


### PR DESCRIPTION
I found the documentation for Lineage lacking--basically, I couldn't find Lineage in the Datafold app. It wasn't obvious to me that you had to go to Catalog and click on a table to see its Lineage.

I've added a few points that I think will help someone with that. 

It's a bit of an awkward fit because the Features pages (lineage, catalog, diff, alerts) are framed more as "here are the great benefits" more than "how-to docs." I think longer term, these features deserve their own explainers in the broader docs section; even though they're (by design) not technically complex to use, the user still needs some basic instructions that don't really belong in the Features page.

But, I think this is worth merging as a quick fix / incremental improvement until we create a more holistic solution.