### PR TITLE
add walkthrough of toml

### DIFF
--- a/docs/os_diff/how_to_use.md
+++ b/docs/os_diff/how_to_use.md
@@ -224,8 +224,6 @@ There are options!
 - Alternatively, you can have project-specific TOML files stored in each project. This has the benefit of each file being simpler and specific to a project. 
   - However, be sure to exclude the TOML file in your `.gitignore` if it includes sensitive information such as passwords.
 
-In both cases, we recommend storing sensitive information such as passwords as [environmental variables](https://linuxhint.com/set-environment-variable-zsh/) in a file such as `.zshrc`.
-
 ## How to use from Python
 
 API reference: [https://data-diff.readthedocs.io/en/latest/](https://data-diff.readthedocs.io/en/latest/)

--- a/docs/os_diff/how_to_use.md
+++ b/docs/os_diff/how_to_use.md
@@ -222,7 +222,7 @@ There are options!
 
 - You could create a single file that has various configurations that are used for multiple projects. This might be stored in your home directory. This has the benefit of everything being in one place.
 - Alternatively, you can have project-specific TOML files stored in each project. This has the benefit of each file being simpler and specific to a project. 
-  - However, be sure to exclude the TOML file in your `.gitignore` if it includes sensitive information such as passwords.
+  - _Note: be sure to exclude the TOML file in your `.gitignore`, especially if it includes sensitive information such as passwords._
 
 ## How to use from Python
 

--- a/docs/os_diff/how_to_use.md
+++ b/docs/os_diff/how_to_use.md
@@ -199,7 +199,7 @@ data-diff \
 
 In summary, the command above will compare between `orders` and `orders_backup` using the `postgres_analytics` run, while also using additional parameters: `-k` and `-w`.
 
-### Inheritance and overriding parameters
+**Inheritance and overriding parameters**
 
 If you review the TOML configuration file above, you'll see that that `verbose = true` is set the `run.default` parameters, which is then overridden by the `postgres_analytics` to set `verbose = false`. 
 


### PR DESCRIPTION
I've added more detail to the docs explaining how to use a TOML file. In the future, I'd like to create a Loom, but I think we could consider merging this as an incremental improvement. I'm open to feedback and ideas.

Medium-term, I'd like to restructure this so the TOML config setup and walkthrough is not buried far down the `How to Use` page. However, I'd like to prioritize this update and then separately consider the structure, since I believe users can benefit today from this additional detail about how to use a config file.