### PR TITLE
add information about duckdb support and remove nonspecific implementation plans

### DIFF
--- a/docs/os_diff/databases_we_support.md
+++ b/docs/os_diff/databases_we_support.md
@@ -19,12 +19,7 @@ If a database is not on the list, we'd still love to support it. Please [open an
 | Trino         | `trino://<username>:<password>@<hostname>:8080/<database>`                                                                          |  💛    |
 | Clickhouse    | `clickhouse://<username>:<password>@<hostname>:9000/<database>`                                                                     |  💛    |
 | Vertica       | `vertica://<username>:<password>@<hostname>:5433/<database>`                                                                        |  💛    |
-| ElasticSearch |                                                                                                                                     |  📝    |
-| Planetscale   |                                                                                                                                     |  📝    |
-| Pinot         |                                                                                                                                     |  📝    |
-| Druid         |                                                                                                                                     |  📝    |
-| Kafka         |                                                                                                                                     |  📝    |
-| DuckDB        |                                                                                                                                     |  📝    |
+| DuckDB        | `duckdb://<database>@<dbpath>`                                                                                                      |  💛    |
 | SQLite        |                                                                                                                                     |  📝    |
 
 * 💚: Implemented and thoroughly tested.

--- a/docs/os_diff/how_to_install.md
+++ b/docs/os_diff/how_to_install.md
@@ -36,6 +36,8 @@ Then, you will need to install one or more driver(s) specific to the database(s)
 
 - `pip install 'data-diff[vertica]'`
 
+- `pip install 'data-diff[duckdb]'`
+
 - For BigQuery, see: https://pypi.org/project/google-cloud-bigquery/
 
 You can also install several drivers at once:


### PR DESCRIPTION
- Indicate that we now support DuckDB. 🦆 
- Remove "implementation planned" for all but SQLite.
  - Note that we *will* implement support for more databases, but will be more specific with our implementation plans as we collect feedback and prioritize, and will update the docs accordingly when that information is available.
  - If you're reading this and wish for us to support a specific database, [please open an issue (or add to an existing issue) in the data-diff repo](https://github.com/datafold/data-diff/issues).