### PR TITLE
update codeowners of docs/os_diff

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 * @williebsweet @dlawin @kylemcnair @leoebfolsom
 
 # OS-Diff
-/docs/os_diff/ @erezsh
+/docs/os_diff/ @erezsh @williebsweet @dlawin @kylemcnair @leoebfolsom


### PR DESCRIPTION
This PR makes the entire Datafold PX team codeowners of the os_diff section of the repo. This ensures anyone on the team is able to respond to issues such as broken links, typos, etc.