### PR TITLE
switch to data-diff

### DIFF
--- a/docs/os_diff/dbt_integration.md
+++ b/docs/os_diff/dbt_integration.md
@@ -25,7 +25,7 @@ import DbtDemo from '../../static/img/dbt_demo.gif';
     ```
 2. Install our free, open-source CLI tool and the Snowflake database connector.
     ```bash
-    pip install data-diff 'sqeleton[snowflake]' -U
+    pip install data-diff 'data-diff[snowflake]' -U
     ```
 3. Add the following data_diff variables to your dbt_project.yml.
     ```bash


### PR DESCRIPTION
You don't need to use sqeleton to install database connectors. Instead, you can use data-diff