### PR TITLE
[PX-389] add githbub app pereqs to docs

### DIFF
--- a/docs/integrations/git/github.md
+++ b/docs/integrations/git/github.md
@@ -8,6 +8,12 @@ title: GitHub
 If you are on an on-prem deployment, you should first create a GitHub App for the integration. See [GitHub integration for Datafold on-prem](on-prem/content/github_on-prem.md) before proceeding with this tutorial.
 :::
 
+:::info Prerequisites
+* Your Datafold user must have admin permissions
+* Your GitHub account must be a member of the GitHub organization where the app is to be installed
+* Approval from a GitHub repo admins or GitHub organization owner is required
+:::
+
 To begin, navigate to **Admin** -> **Settings**. Then, click on Git in the sidebar to configure a new GitHub integration.
 
 ![](../../../static/img/github_setup.png)

--- a/docs/integrations/git/github.md
+++ b/docs/integrations/git/github.md
@@ -9,9 +9,9 @@ If you are on an on-prem deployment, you should first create a GitHub App for th
 :::
 
 :::info Prerequisites
-* Your Datafold user must have admin permissions
-* Your GitHub account must be a member of the GitHub organization where the app is to be installed
-* Approval from a GitHub repo admin or GitHub organization owner is required
+* Datafold admin permissions
+* Your GitHub account must be a member of the GitHub organization where the Datafold app is to be installed
+* Approval of your request to add the Datafold app to your repo must be granted by a GitHub repo admin or GitHub organization owner
 :::
 
 To begin, navigate to **Admin** -> **Settings**. Then, click on Git in the sidebar to configure a new GitHub integration.
@@ -25,5 +25,11 @@ To set up a new integration click on the repository field to access the **Instal
 From here, GitHub will redirect you to login to your account and choose which organization you would like to connect. After choosing the right organization, you may choose to allow access to all repositories or specific ones. 
 
 When complete, you'll be redirected back to Datafold, where you can choose the appropriate repository for connection. 
+
+:::tip
+If your GitHub account does not have permission to add the Datafold app, you can request that your GitHub admin approve and install the app.
+
+Once installed, click refresh and the newly added repos will appear in the dropdown list.
+:::
 
 To complete the setup, click **Save**!

--- a/docs/integrations/git/github.md
+++ b/docs/integrations/git/github.md
@@ -11,7 +11,7 @@ If you are on an on-prem deployment, you should first create a GitHub App for th
 :::info Prerequisites
 * Your Datafold user must have admin permissions
 * Your GitHub account must be a member of the GitHub organization where the app is to be installed
-* Approval from a GitHub repo admins or GitHub organization owner is required
+* Approval from a GitHub repo admin or GitHub organization owner is required
 :::
 
 To begin, navigate to **Admin** -> **Settings**. Then, click on Git in the sidebar to configure a new GitHub integration.


### PR DESCRIPTION
Adding requirements for installing the Datafold GitHub integration


<img width="1211" alt="Screen Shot 2023-02-16 at 12 02 56 PM" src="https://user-images.githubusercontent.com/40182913/219474513-db24af9c-d69a-4b05-94d8-355da3e6ca54.png">


Need to do the same for GitLab, but I'll do that separately