### PR TITLE
[PX-395] add second key to composite key example

### DIFF
--- a/docs/integrations/orchestration/dbt_adv_config.md
+++ b/docs/integrations/orchestration/dbt_adv_config.md
@@ -45,7 +45,7 @@ models:
       - name: user_id
         meta:
           primary-key: true
-      - name: version_id
+      - name: company_id
         meta:
           primary-key: true
 ```
@@ -67,7 +67,10 @@ In the case of a compound Primary Key, you can assign a second column (or more):
 models:
   - name: users
     columns:
-      - name: version_id
+      - name: user_id
+        tags:
+          - primary-key
+      - name: company_id
         tags:
           - primary-key
 ```


### PR DESCRIPTION
I noticed that the composite key example only has a single key, and thought giving a more explicit example is helpful

I also renamed the example keys from `user_id` and `version_id` to `user_id` and `company_id` - I think that's a more plausible and common example.

**current state**
<kbd>
<img width="577" alt="Screen Shot 2023-02-21 at 9 50 48 AM" src="https://user-images.githubusercontent.com/40182913/220423973-363da30f-7f5f-4ef9-bc6a-d95fe40d3563.png">
</kbd>

**proposed**:
<kbd>
<img width="898" alt="Screen Shot 2023-02-21 at 10 01 08 AM" src="https://user-images.githubusercontent.com/40182913/220424137-daa7b0ab-e9d4-49cb-9ecc-8a34e2927ca0.png">
</kbd>
