### PR TITLE
[PX-394] link check in CI

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -1,0 +1,15 @@
+name: Check Markdown links
+
+on: push
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+        check-modified-files-only: 'yes'
+        base-branch: 'main'
+        use-verbose-mode: 'yes'
+        config-file: 'mlc_config.json'

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,7 @@
+{
+    "ignorePatterns": [
+      {
+        "pattern": ".*img\/.*\.png$"
+      }
+    ]
+  }


### PR DESCRIPTION
This PR adds checks for broken links in CI. It only checks modified files.

Docusaurus has an [onBrokenLinks](https://docusaurus.io/docs/api/docusaurus-config#onBrokenLinks) config, but it is only available for production builds.

There are quite a few tools that check for links on broken sites, and I tried out several different tools in the course of this PR. [Markdown link check](https://github.com/tcort/markdown-link-check) can be run prior to deploy (several tools required a url), and seems to have quite a few config options.

No broken links ✅ 
<img width="644" alt="Screen Shot 2023-02-21 at 6 53 20 PM" src="https://user-images.githubusercontent.com/40182913/220525991-9f039cb0-62bd-4147-9e59-97f7153718c9.png">

With broken links ❌ 
<img width="598" alt="Screen Shot 2023-02-21 at 6 54 55 PM" src="https://user-images.githubusercontent.com/40182913/220526024-f9356012-6202-4d76-8e6f-394a538f1baf.png">

Next steps
* This only checks modified files. I think it makes sense to add a job that runs weekly to check the whole site.
* Need to check for existing broken links, and fix as needed.

CI improvements:
* It would be neat if this popped a comment onto the PR, but I'll try to add that down the road, this seemed like a decent MVP.
