### PR TITLE
[PX-401] rename docs and open source tabs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -76,10 +76,10 @@ const config = {
           {
             type: 'doc',
             docId: 'overview',
-            label: 'Docs',
+            label: 'Datafold Cloud',
             position: 'left',
           },
-          {type: 'docSidebar', sidebarId: 'os_diff', label: 'Open Source', position: 'left'},
+          {type: 'docSidebar', sidebarId: 'os_diff', label: 'Open Source Data Diff', position: 'left'},
           {type: 'docSidebar', sidebarId: 'api', label: 'APIs', position: 'left'},
           {type: 'docSidebar', sidebarId: 'guides', label: 'Guides', position: 'left'},
           // {to: '/blog', label: 'Blog', position: 'left'}, // remove to turn on blog


### PR DESCRIPTION
Per discussion [here](https://datafold.slack.com/archives/C03MWG27G01/p1677091357072649), this renames tabs
* Rename “Docs” tab -> Datafold Cloud
* Rename “Open Source” tab -> “Open Source Data Diff”

To avoid needing to update links, I only changed the label. Assuming we'll continue iterating and this is just a quick win.

We also discussed moving the API and Guides tab, but I'll do that in a separate PR because it's more involved.

Rendered:
<kbd>
<img width="864" alt="Screen Shot 2023-02-22 at 12 58 07 PM" src="https://user-images.githubusercontent.com/40182913/220757509-006ea4e1-3005-48af-8e81-936c0da60df5.png">
</kbd>