### PR TITLE
[PX 403] broken anchors

### DIFF
--- a/docs/api/content/graphql.md
+++ b/docs/api/content/graphql.md
@@ -10,7 +10,7 @@ To use the Datafold GraphQL API, you should first [create a Datafold API Key](..
 :::
 
 * [GraphQL Examples](graphql.md#graphql-examples)
-* [GraphQL Schema](graphql.md#graphql-chema)
+* [GraphQL Schema](graphql.md#graphql-schema)
 
 ## API Info
 

--- a/docs/integrations/data_warehouses/content/postgres/postgres_aurora.md
+++ b/docs/integrations/data_warehouses/content/postgres/postgres_aurora.md
@@ -9,7 +9,7 @@ This will guide you through setting up Column-level Lineage with AWS Aurora usin
 **Steps to complete:**
 
 1. [Setup Postgres with Permissions](postgres.md#run-sql-script)
-2. [Increase the logging verbosity of Postgres](postgres_aurora.md#increased-verbosity) so Datafold can parse lineage
+2. [Increase the logging verbosity of Postgres](postgres_aurora.md#increase-logging-verbosity) so Datafold can parse lineage
 3. [Set up an account for fetching the logs from CloudWatch.](postgres_aurora.md#connect-datafold-to-cloudwatch)
 4. [Configure your data source in Datafold](postgres_aurora.md#configure-in-datafold)
 

--- a/docs/on-prem/content/slack_on-prem.md
+++ b/docs/on-prem/content/slack_on-prem.md
@@ -13,7 +13,7 @@ On-prem deployments are an Enterprise feature. Please email [sales@datafold.com]
 **Steps to complete:**
 
 1. [Create a Slack Application](slack_on-prem.md#create-a-slack-app)
-2. [Configure Slack in Datafold](github_on-prem.md#complete-github-configuration)
+2. [Configure Slack in Datafold](slack_on-prem.md#configure-slack-in-datafold)
 
 ## Create a Slack App
 

--- a/docs/os_diff/how_to_use/how_to_use_with_command_line.md
+++ b/docs/os_diff/how_to_use/how_to_use_with_command_line.md
@@ -28,7 +28,7 @@ Let's break this down. Assume there are two tables stored in two different datab
 - `table_a` is the name of the table in the first database.
 - `database_b` will be a string that `data-diff` uses to connect to the database where the second table is stored.
 - `table_b` is the name of the second table in the second database.
-- `[OPTIONS]` can be replaced with a variety of additional commands, [detailed here](#options).
+- `[OPTIONS]` can be replaced with a variety of additional commands, [detailed here](./options).
 
 Usually, `database_a` and `database_b` will be URL connection strings. However, when `--conf` is specified, they can also be the names of the database configurations defined in a [TOML configuration file](./how_to_use_with_toml).
 


### PR DESCRIPTION
When adding a link checker to CI, the checker flagged a few missing anchors. This PR fixes four missing anchors.

```
GitHub linkcheck https://docs.datafold.com/
Done crawling.                   

https://docs.datafold.com/api/content/graphql/
- (15:7183) 'GraphQL ..' => https://docs.datafold.com/api/content/graphql#graphql-chema (HTTP 200 but missing anchor)
  - redirect path:
    - https://docs.datafold.com/api/content/graphql (301)
    - /api/content/graphql/ (200)

https://docs.datafold.com/integrations/data_warehouses/content/postgres/postgres_aurora/
- (15:12225) 'Increase..' => https://docs.datafold.com/integrations/data_warehouses/content/postgres/postgres_aurora#increased-verbosity (HTTP 200 but missing anchor)
  - redirect path:
    - https://docs.datafold.com/integrations/data_warehouses/content/postgres/postgres_aurora (301)
    - /integrations/data_warehouses/content/postgres/postgres_aurora/ (200)

https://docs.datafold.com/on-prem/content/slack_on-prem/
- (15:9611) 'Configur..' => https://docs.datafold.com/on-prem/content/github_on-prem#complete-github-configuration (HTTP 200 but missing anchor)
  - redirect path:
    - https://docs.datafold.com/on-prem/content/github_on-prem (301)
    - /on-prem/content/github_on-prem/ (200)

https://docs.datafold.com/os_diff/how_to_use/how_to_use_with_command_line/
- (15:14390) 'detailed..' => https://docs.datafold.com/os_diff/how_to_use/how_to_use_with_command_line/#options (HTTP 200 but missing anchor)

Warnings. Checked 6197 links, 209 destination URLs (189 ignored), 8 have warnings.