### PR TITLE
Removed "base branch selection strategy" from dbt Cloud docs

### DIFF
--- a/docs/integrations/orchestration/dbt_cloud/configuration.md
+++ b/docs/integrations/orchestration/dbt_cloud/configuration.md
@@ -35,4 +35,4 @@ Complete the configuration by specifying the following fields:
 | Sampling confidence | The confidence to apply when sampling. |
 | Sampling Threshold | Sampling will be disabled automatically if tables are smaller than specified threshold. If unspecified, default values will be used depending on the Data Source type. |
 
-Click save. Now that you've set up the integration, Datafold will diff your impacted tables whenever you push commits to a PR. A summaryof the diff will appear in GitHub, and detailed results will appear in the Datafold app.
+Click save. Now that you've set up the integration, Datafold will diff your impacted tables whenever you push commits to a PR. A summary of the diff will appear in GitHub, and detailed results will appear in the Datafold app.

--- a/docs/integrations/orchestration/dbt_cloud/configuration.md
+++ b/docs/integrations/orchestration/dbt_cloud/configuration.md
@@ -25,7 +25,6 @@ Complete the configuration by specifying the following fields:
 | Skip for pull/merge requests | When selected, the Datafold CI pipeline won't be run on pull/merge requests. |
 | Job that builds pull requests  | This becomes selectable after a valid API key is filled in. Select the job that builds pull requests. |
 | Primary key tag | See [dbt Integration](../dbt_adv_config.md). This should be set to a value such as `primary-key` which will also be used in your dbt project configuration (yaml files and config blocks). |
-| Base branch commit selection strategy | Select "Merge Base" to compare your PR to the commit in the main branch that is defined as part of the PR. Select "Latest" to compare your PR branch to the latest commit in the main branch.  |
 | Sync metadata on every push to production | When selected, this will sync the manifest.json artifact from the dbt run with Datafold every time a push happens on the default branch.|
 | Sync metadata on a schedule | Set a schedule to synchronize the dbt metadata (columns and table descriptions, tags, owners, etc), use this when you run the production job on a schedule. |
 | Files to ignore | If defined, the files matching the pattern will be ignored in the PRs. The pattern uses the syntax of `.gitignore`. Excluded files can be re-included by using the negation; re-included files can be later re-excluded again to narrow down the filter. For example, to exclude everything except the `/dbt` folder, but not the dbt `.md` files, do:`*!dbt/*dbt/*.md`.|


### PR DESCRIPTION
The option was removed from UI because we should always use "merge base" for dbt Cloud configs.
<img width="1840" alt="image" src="https://user-images.githubusercontent.com/18095933/224966322-843c5cbb-a7ac-459e-94a1-d5b66bff293f.png">
