### PR TITLE
avoid missing dependencies errors

### DIFF
--- a/docs/development_testing/open_source.md
+++ b/docs/development_testing/open_source.md
@@ -25,7 +25,7 @@ Navigate to your dbt project, and install data-diff and a database connector.
   <TabItem value="snowflake">
 
   ```zsh
-  pip install data-diff 'data-diff[snowflake]' -U
+  pip install data-diff 'data-diff[snowflake,dbt]' -U
   ```
 
   </TabItem>
@@ -47,28 +47,28 @@ Navigate to your dbt project, and install data-diff and a database connector.
   <TabItem value="redshift">
 
   ```zsh
-  pip install data-diff 'data-diff[redshift]' -U
+  pip install data-diff 'data-diff[redshift,dbt]' -U
   ```
 
   </TabItem>
   <TabItem value="postgres">
 
   ```zsh
-  pip install data-diff 'data-diff[postgres]' -U
+  pip install data-diff 'data-diff[postgres,dbt]' -U
   ```
 
   </TabItem>
   <TabItem value="databricks">
 
   ```zsh
-  pip install data-diff 'data-diff[databricks]' -U
+  pip install data-diff 'data-diff[databricks,dbt]' -U
   ```
 
   </TabItem>
   <TabItem value="duckdb">
 
   ```zsh
-  pip install data-diff 'data-diff[duckdb]' -U
+  pip install data-diff 'data-diff[duckdb,dbt]' -U
   ```
 
   </TabItem>

--- a/docs/development_testing/open_source.md
+++ b/docs/development_testing/open_source.md
@@ -32,7 +32,7 @@ Navigate to your dbt project, and install data-diff and a database connector.
   <TabItem value="bigquery">
 
   ```zsh
-  pip install data-diff google-cloud-bigquery -U
+pip install data-diff 'data-diff[dbt]' google-cloud-bigquery -U
   ```
   <details>
     <summary>Additional BigQuery details</summary>


### PR DESCRIPTION
Some users are missing dependencies for `data-diff --dbt`. Slightly more verbose installation commands prevents this from happening.