### PR TITLE
remove text, align language with website copy

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -6,14 +6,12 @@ slug: /
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Whether you're an individual looking to get started with **Development Testing** or a team looking to implement **Deployment Testing**, this section gives you the fastest way to get started with Datafold.
-
 <Tabs>
   <TabItem value="diff_ui" label="Development Testing" >
     <table>
       <tr>
           <td width="50%">
-          See the impact code changes have on the data as you develop. <a href="development_testing">Learn more &rarr;</a>
+          Develop dbt models faster by testing as you code. <br /><a href="development_testing/open_source">Learn more &rarr;</a>
           </td>
           <td width="50%">
           <img src={'/img/open_source_output.png'} />
@@ -26,13 +24,10 @@ Whether you're an individual looking to get started with **Development Testing**
     <table>
       <tr>
           <td width="50%">
-          Collaborate with your team to deploy quickly and confidently. <a href="deployment_testing">Learn more &rarr;</a>
+          Prevent bad dbt deploys with automated testing in CI. <br /><a href="deployment_testing">Learn more &rarr;</a>
           </td>
           <td width="50%"><video src="https://datafold-public.s3.us-west-2.amazonaws.com/small-video-01.mp4" preload="metadata" autoplay="autoplay" loop="loop" muted="" width="102%" height="auto%"></video></td>
       </tr>
     </table>
   </TabItem>
 </Tabs>
-
-### Interested?
-Check out our [quickstart guide](development_testing/open_source) to start Development Testing with Datafold Open Source!


### PR DESCRIPTION
This PR removes some extra text and aligns the language describing development/deployment testing with the website copy.

I think there's some more stuff we can add to this page, but this edit cleans it up and gives us a good place to iterate from.

<img width="580" alt="Screenshot 2023-05-02 at 17 26 38" src="https://user-images.githubusercontent.com/1799931/235812499-d452eaa0-5da9-4e0a-a788-070f94bf79e6.png">
<img width="552" alt="Screenshot 2023-05-02 at 17 26 32" src="https://user-images.githubusercontent.com/1799931/235812504-2e048022-c1c8-4c17-a491-440a3ab8ad8c.png">
<img width="536" alt="Screenshot 2023-05-02 at 17 26 27" src="https://user-images.githubusercontent.com/1799931/235812505-35082626-d5c8-4c6a-8ffc-c44667dded1e.png">

