### PR TITLE
updating docs to align with products

### DIFF
--- a/docs/deployment_testing.md
+++ b/docs/deployment_testing.md
@@ -1,6 +1,7 @@
 ---
 id: deployment_testing
 title: Deployment Testing
+sidebar_label: Getting Started
 pagination_next: deployment_testing/data_sources
 hide_table_of_contents: true
 ---
@@ -9,8 +10,8 @@ hide_table_of_contents: true
 
 ### See the impact of your change right in the pull request. Prevent regressions and streamline pull request reviews.
 
-:::tip Datafold in CI
-🔧 Interested in adding Datafold to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
+:::tip Team Cloud
+🔧 Interested in adding Datafold Team Cloud to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
 :::
 
 ## Getting Started for Customers

--- a/docs/development_testing/cloud.md
+++ b/docs/development_testing/cloud.md
@@ -1,8 +1,8 @@
 ---
 sidebar_position: 2
 id: cloud
-title: Datafold Cloud
-sidebar_label: Cloud
+title: 'Development Testing: Community Cloud'
+sidebar_label: Community Cloud
 hide_table_of_contents: true
 ---
 import Tabs from '@theme/Tabs';
@@ -12,8 +12,8 @@ import TabItem from '@theme/TabItem';
 
 ### Create a free Datafold Cloud account to view and save value-level impact reports generated while developing in your dbt local environment.
 
-:::tip Datafold in CI
-🔧 Interested in adding Datafold to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
+:::tip Team Cloud
+🔧 Interested in adding Datafold Team Cloud to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
 :::
 
 ### Set up your dbt project

--- a/docs/development_testing/open_source.md
+++ b/docs/development_testing/open_source.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 1
 id: open_source
-title: data-diff
+title: 'Develpment Testing: Open Source'
 sidebar_label: Open Source
 hide_table_of_contents: true
 ---
@@ -13,8 +13,8 @@ import TabItem from '@theme/TabItem';
 
 ### See how every change to dbt code affects the data produced in the modified model and downstream.
 
-:::tip Datafold in CI
-🔧 Interested in adding Datafold to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
+:::tip Team Cloud
+🔧 Interested in adding Datafold Team Cloud to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
 :::
 
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -1,10 +1,16 @@
 ---
 id: getting_started
-title: Getting Started
+title: Develop faster without breaking data
 slug: /
+hide_table_of_contents: true
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+
+## Automated testing for data engineers
+
+### Don’t wait for stakeholders, monitoring tools, and customers to tell you about broken data.
+### Adopt a workflow that makes data quality issues a thing of the past.
 
 <Tabs>
   <TabItem value="diff_ui" label="Development Testing" >


### PR DESCRIPTION
Updating our getting started pages to align with https://www.datafold.com/pricing

I'm balancing the need to convey the overarching categories of dev testing and deployment testing--dev testing can be free or paid; deployment testing is only paid--while also conveying the 4 product types (two paid, two not-paid).

<img width="1082" alt="Screenshot 2023-05-08 at 09 23 01" src="https://user-images.githubusercontent.com/1799931/236883485-6baea643-7e38-4e3c-8b32-94392a4d9163.png">

Well, there are 4 product types, but I did not add a separate page/callout of Enterprise Cloud here, because:

- I wanted to get this iterative improvement across the line, given Richie's request that we be consistent with our use of product names.
- I had initially thought to add a "book a meeting" callout for Enterprise Cloud on the Deployment Testing page, but Clay recommended I not bother until we have a proper page intro'ing people to Enterprise Cloud, because otherwise it will just confuse people.

So I thought it was best to ship this PR, and then separately think about how best to share Enterprise Cloud in the docs.
<img width="1251" alt="Screenshot 2023-05-08 at 09 44 44" src="https://user-images.githubusercontent.com/1799931/236883668-ed54b994-41fb-4afc-ace2-9a42e19be8c7.png">
<img width="1272" alt="Screenshot 2023-05-08 at 09 44 37" src="https://user-images.githubusercontent.com/1799931/236883673-8eabc45d-733e-4dc8-89e9-8587dce2fad1.png">
<img width="1256" alt="Screenshot 2023-05-08 at 09 44 33" src="https://user-images.githubusercontent.com/1799931/236883676-a22ac38e-1f5a-4790-bd64-86e7b0c7f993.png">

