### PR TITLE
better menu structure consistency between dev and depl testing

### DIFF
--- a/docs/deployment_testing.md
+++ b/docs/deployment_testing.md
@@ -1,8 +1,8 @@
 ---
 id: deployment_testing
 title: Deployment Testing
-sidebar_label: Getting Started
-pagination_next: deployment_testing/data_sources
+sidebar_label: Team Cloud
+pagination_next: deployment_testing/getting_started_for_customers
 hide_table_of_contents: true
 ---
 
@@ -76,12 +76,3 @@ hide_table_of_contents: true
         </td>
     </tr>
 </table>
-
----
-
-## Getting Started for Customers
-
-1. Connect your [Data Source](/deployment_testing/data_sources)
-2. Integrate with [Source Control](/deployment_testing/source_control)
-3. Integrate with [dbt Core/Cloud](/deployment_testing/dbt)
-4. [Optional] Connect [Data Apps](/deployment_testing/data_apps)

--- a/docs/deployment_testing/getting_started_for_customers.md
+++ b/docs/deployment_testing/getting_started_for_customers.md
@@ -1,0 +1,19 @@
+---
+id: getting_started_for_customers
+title: Getting Started with Deployment Testing
+sidebar_label: Getting Started for Customers
+pagination_next: deployment_testing/data_sources
+hide_table_of_contents: true
+---
+
+:::tip Team Cloud
+🔧 Interested in adding Datafold Team Cloud to your CI pipeline? [Let's talk!](https://calendly.com/d/zkz-63b-23q/see-a-demo?email=clay%20analytics%40datafold.com&first_name=Clay&last_name=Moeller&a1=) ☎️
+:::
+<br />
+
+## Getting Started with Deployment Testing
+
+1. Connect your [Data Source](/deployment_testing/data_sources)
+2. Integrate with [Source Control](/deployment_testing/source_control)
+3. Integrate with [dbt Core/Cloud](/deployment_testing/dbt)
+4. [Optional] Connect [Data Apps](/deployment_testing/data_apps)

--- a/docs/deployment_testing/getting_started_for_customers.md
+++ b/docs/deployment_testing/getting_started_for_customers.md
@@ -1,7 +1,7 @@
 ---
 id: getting_started_for_customers
 title: Getting Started with Deployment Testing
-sidebar_label: Getting Started for Customers
+sidebar_label: Getting Started
 pagination_next: deployment_testing/data_sources
 hide_table_of_contents: true
 ---

--- a/sidebars.js
+++ b/sidebars.js
@@ -29,6 +29,7 @@ const sidebars = {
       link: {type: 'doc', id: 'deployment_testing'},
       items: [
         'deployment_testing',
+        'deployment_testing/getting_started_for_customers',
         {
           type: 'category',
           label: 'Data Source',


### PR DESCRIPTION
I thought it made sense to have "Team Cloud" in the menu under both Dev and Deployment testing, which makes it clear that you can use Team Cloud in these two contexts. I also separated out the Getting Started for Customers page, which was buried at the bottom of the page formerly known as Getting Started.