### PR TITLE
Add lineage to enterprise features & for doc reference

### DIFF
--- a/docs/enterprise_accounts/catalog-lineage.md
+++ b/docs/enterprise_accounts/catalog-lineage.md
@@ -1,0 +1,25 @@
+---
+id: catalog-lineage
+title: Column-level Lineage
+pagination_prev: enterprise_accounts/sso
+pagination_next: enterprise_accounts/custom_integrations/github_vpc
+---
+## Lineage
+![](../../static/img/catalog_landing.png)
+With the Datafold's Lineage tool, you can quickly see row counts, nulls, and column distributions for tables in your data warehouse.
+
+To include more details in Lineage, you can sync metadata from dbt and your data warehouse to create a single source of truth. You can implement custom tags to easily categorize and filter the data sets. 
+
+## Accessing column-level Lineage
+
+![](../../static/img/lineage_detail.png)
+After connecting your data warehouse, Datafold parses the query logs to construct and visualize dependencies at both the table and column levels. See how data is produced, consumed, and transformed. Datafold supports complex queries, such as correlated subqueries, `CASE WHEN` statements, and window functions.
+
+No additional developer resources are needed to unlock this capability. Simply connect your data warehouse and explore your lineage graph. 
+
+To view the column-level Lineage of any table in your warehouse:
+
+* Navigate to Lineage.
+* Click on any table name in the data browser.
+* By default, table-level lineage will be shown. 
+* Click on the Columns dropdown of any table to view column-level lineage.

--- a/docs/enterprise_accounts/catalog-lineage.md
+++ b/docs/enterprise_accounts/catalog-lineage.md
@@ -3,6 +3,7 @@ id: catalog-lineage
 title: Column-level Lineage
 pagination_prev: enterprise_accounts/sso
 pagination_next: enterprise_accounts/custom_integrations/github_vpc
+hide_table_of_contents: true
 ---
 ## Lineage
 ![](../../static/img/catalog_landing.png)

--- a/docs/enterprise_accounts/sso.md
+++ b/docs/enterprise_accounts/sso.md
@@ -2,7 +2,7 @@
 id: sso
 title: SSO
 pagination_prev: enterprise_accounts/vpc_deployments
-pagination_next: enterprise_accounts/custom_integrations/catalog-lineage
+pagination_next: enterprise_accounts/catalog-lineage
 ---
 Set up Single Sign-On with one of the following options:
 

--- a/docs/enterprise_accounts/sso.md
+++ b/docs/enterprise_accounts/sso.md
@@ -2,7 +2,7 @@
 id: sso
 title: SSO
 pagination_prev: enterprise_accounts/vpc_deployments
-pagination_next: enterprise_accounts/custom_integrations/github_vpc
+pagination_next: enterprise_accounts/custom_integrations/catalog-lineage
 ---
 Set up Single Sign-On with one of the following options:
 

--- a/docs/enterprise_accounts/sso.md
+++ b/docs/enterprise_accounts/sso.md
@@ -2,7 +2,7 @@
 id: sso
 title: SSO
 pagination_prev: enterprise_accounts/vpc_deployments
-pagination_next: enterprise_accounts/catalog-lineage
+pagination_next: enterprise_accounts/custom_integrations/github_vpc
 ---
 Set up Single Sign-On with one of the following options:
 


### PR DESCRIPTION
1. Lineage docs links in app currently broken - would like to resurrect a minimal page to help there.
2. Can hide it from public, figured SEO wise it's easier and better to put it in Enterprise features. Lmk if there's a strong reason not to do so.