### PR TITLE
fix syntax of filter clause in dbt advanced configs

### DIFF
--- a/docs/guides/dbt_advanced_configs.md
+++ b/docs/guides/dbt_advanced_configs.md
@@ -90,7 +90,9 @@ models:
         datadiff:
           filter: "user_id > 2350"
           # or
-          filter: "source_timestamp >= current_date() - 7
+          filter: "source_timestamp >= current_date() - 7"
+          # or
+          filter: "created_at >= '2021-01-01'"
 ```
 
 ### Include / Exclude Columns


### PR DESCRIPTION
Caught a syntax error (missing `"`) when working with a customer. 

Also added another date example for the same config.